### PR TITLE
Fixed Whitesource product name

### DIFF
--- a/resources/whitesource/wss-pull_request-scan.config
+++ b/resources/whitesource/wss-pull_request-scan.config
@@ -12,7 +12,7 @@
 #######################
 
 # Required apiKey and userKey are expected to be provided on the CLI
-productName=LIT vocab term JS
+productName=SDK
 projectName=lit-vocab-term-js
 
 wss.url=https://saas.whitesourcesoftware.com/agent

--- a/resources/whitesource/wss-push-scan.config
+++ b/resources/whitesource/wss-push-scan.config
@@ -12,7 +12,7 @@
 #######################
 
 # Required apiKey and userKey are expected to be provided on the CLI
-productName=LIT vocab term JS
+productName=SDK
 projectName=lit-vocab-term-js
 
 wss.url=https://saas.whitesourcesoftware.com/agent


### PR DESCRIPTION
All the SDK projects should be under the SDK product to ease policy management. The previous product name was an error, but it was only detected after merge when the inventory was updated.